### PR TITLE
Forward children to connected component

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -24,7 +24,7 @@ const connectCreator: ConnectCreator = (mapDispatchToProps, mapStateToProps) =>
             ...this.stateToProps,
             ...this.dispatchToProps,
           },
-        });
+        }, this.$slots.default);
       },
       computed: {
         stateToProps() {


### PR DESCRIPTION
I had a connected component which renders it's content inside another component. This was not possible since `this.$slots.default` was null. This PR "forwards" the default slots to the connected component.