### PR TITLE
Forward scoped slots

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -17,7 +17,8 @@ const connectCreator: ConnectCreator = (mapStateToProps, mapDispatchToProps) =>
         ...this.$options.propsData,
         ...this.stateToProps,
         ...this.dispatchToProps,
-        },
+      },
+      scopedSlots: this.$scopedSlots
       }, this.$slots.default);
     },
     computed: {


### PR DESCRIPTION
Scoped slots should be forwarded also (people claim that vue has "fewer" concepts then react...when in reality it's the exact opposite...vue has several concepts that are just "props" in react....anyway I digress)