### PR TITLE
Fix own props reactivity

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -15,7 +15,7 @@ const connectCreator: ConnectCreator = (mapStateToProps, mapDispatchToProps) =>
       return h(component, {
         on: this._events,
         props: {
-          ...this.$options.propsData,
+          ...this.$props,
           ...this.stateToProps,
           ...this.dispatchToProps,
         },

--- a/test/components/App.vue
+++ b/test/components/App.vue
@@ -1,7 +1,7 @@
 <template>
   <provider v-bind:store="store">
     <div id="child">
-      <counter id="counter" />
+      <counter v-bind="{skip}" id="counter" />
     </div>
   </provider>
 </template>
@@ -27,6 +27,7 @@ const App = {
   },
   data() {
     return {
+      skip: 0,
       store,
     };
   },

--- a/test/components/Counter.vue
+++ b/test/components/Counter.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <span id="count">{{ count }}</span>
+    <span id="count">{{ countWithSkip }}</span>
     <button id="button-increment" v-on:click="actions.increment()">
       Increment
     </button>
@@ -13,7 +13,15 @@
 <script>
 const Counter = {
   name: 'Counter',
-  props: ['count', 'actions'],
+  props: ['count', 'actions', 'skip'],
+  computed: {
+    countWithSkip () {
+      const skip = this.skip || 0;
+
+      return Array.from(Array(this.count).keys())
+        .reduce((sum, next) => sum + next + skip, 0)
+    }
+  }
 }
 
 export default Counter;

--- a/test/specs/counter.spec.js
+++ b/test/specs/counter.spec.js
@@ -42,7 +42,7 @@ describe('App', () => {
       expect(spanElem.text()).toBe(storeCount.toString());
     });
 
-    it('should have props.count equal store value after actions', () => {
+    it('should have props.count equal store value after actions', async () => {
       const wrapper = mount(App);
       const childElem = wrapper.find(Counter)[0];
 
@@ -50,10 +50,9 @@ describe('App', () => {
       wrapper.find('#button-increment')[0].trigger('click');
       wrapper.find('#button-decrement')[0].trigger('click');
 
-      Vue.nextTick(() => {
-        const storeCount = store.getState().count;
-        expect(childElem.vm.$props.count).toBe(storeCount);
-      });
+      await Vue.nextTick();
+      const storeCount = store.getState().count;
+      expect(childElem.vm.$props.count).toBe(storeCount);
     });
   });
 });

--- a/test/specs/counter.spec.js
+++ b/test/specs/counter.spec.js
@@ -36,6 +36,21 @@ describe('App', () => {
       expect(counterElem.vm.$props.actions.increment).toBeDefined();
     });
 
+    it('should pass in own props and retain reactivity', async () => {
+      const wrapper = mount(App);
+
+      wrapper.find('#button-increment')[0].trigger('click');
+      wrapper.find('#button-increment')[0].trigger('click');
+
+      await Vue.nextTick();
+
+      wrapper.vm.skip = 2;
+
+      await Vue.nextTick();
+
+      expect(wrapper.find('#count')[0].text()).toBe('5');
+    });
+
     it('should have props.count in span element equal store value', () => {
       const spanElem = mount(App).find('#count')[0];
       const storeCount = store.getState().count;


### PR DESCRIPTION
Although vuedux successfully passes in the components own props through, they seem to lose reactivity. 
I've changed `this.$options.propsData` to `this.$props` and this seems to fix it.

I've included a test case as well (I added a "skip" prop to the counter which is passed in by App, and update that prop by updating that state in app). Before my change, the count remained the same, now it updates according to the "skip".

I also updated the `should have props.count equal store value after actions` test. The assertions were not running at all, so the test only gave the illusion that it was passing.